### PR TITLE
Add AI checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,21 @@
-### Description:
+### Description
 
 Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.
 
+### Checklist
+
+- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
+- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules
+
 ### Review
 
-* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
-* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
-* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
-* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
-* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
-* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
-* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
-* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
-* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
-* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
-* [ ] Existing documentation updated if needed
+- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
+- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
+- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
+- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
+- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
+- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
+- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
+- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
+- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
+- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)


### PR DESCRIPTION
Add AI checklist to PR template. Relevant core PR https://github.com/matomo-org/matomo/pull/23745.

Replaced `*` with `-` for lists and merged the two documentation review items into one.